### PR TITLE
Override a view from Storefront

### DIFF
--- a/app/views/workarea/storefront/products/show.html.haml
+++ b/app/views/workarea/storefront/products/show.html.haml
@@ -1,0 +1,49 @@
+- @title = @product.browser_title
+- @breadcrumbs = @product.breadcrumbs
+
+- content_for :head do
+  - cache "#{@product.cache_key}/head", expires_in: Workarea.config.cache_expirations.product_show_fragment_cache do
+    %meta{ property: 'global-id', content: @product.to_global_id.to_param }
+    = append_partials('storefront.product_head', product: @product)
+
+    %link{ href: product_url(@product), rel: 'canonical' }
+
+    %meta{ name: :description, content: strip_tags(@product.meta_description) }
+
+    %meta{ property: 'og:url', content: url_for(only_path: false) }
+    %meta{ property: 'og:title', content: @product.name }
+    %meta{ property: 'og:type', content: 'product' }
+    - @product.images.each do |image|
+      %meta{ property: 'og:image', content: product_image_url(image, :detail) }
+      %meta{ property: 'og:image:secure_url', content: product_image_url(image, :detail) }
+    %meta{ property: 'og:description', content: strip_tags(@product.meta_description) }
+
+- cache "#{@product.cache_key}/show", expires_in: Workarea.config.cache_expirations.product_show_fragment_cache do
+
+  = render_schema_org(product_schema(@product, related_products: @product.recommendations))
+
+  .view
+    .product-detail-container{ data: { analytics: product_view_analytics_data(@product).to_json } }
+
+      .product-details{ class: "product-details--#{@product.template}" }
+        = render "workarea/storefront/products/templates/#{@product.template}", product: @product
+
+      - if @product.description.present?
+        .product-detail-container__description#description
+          %h2.product-detail-container__description-heading= t('workarea.storefront.products.description')
+          .product-detail-container__description-body!= t('workarea.storefront.products.modified')
+      = append_partials('storefront.product_description', product: @product)
+
+      - if @product.recommendations.any?
+        .recommendations
+          %h2.recommendations__heading= t('workarea.storefront.recommendations.heading')
+          .recommendations__products
+            .grid{ data: { analytics: product_list_analytics_data('Product Recommendations').to_json } }
+              - @product.recommendations.each do |product|
+                .grid__cell.grid__cell--50.grid__cell--33-at-medium.grid__cell--16-at-wide
+                  .product-summary.product-summary--small
+                    = render 'workarea/storefront/products/summary', product: product
+
+      %div{ data: { recommendations_placeholder: recent_views_path } }
+
+      = append_partials('storefront.product_show', product: @product)

--- a/app/views/workarea/storefront/products/show.html.haml
+++ b/app/views/workarea/storefront/products/show.html.haml
@@ -31,7 +31,7 @@
       - if @product.description.present?
         .product-detail-container__description#description
           %h2.product-detail-container__description-heading= t('workarea.storefront.products.description')
-          .product-detail-container__description-body!= t('workarea.storefront.products.modified')
+          .product-detail-container__description-body!= t('workarea.storefront.products.modified', product_name: @product.name)
       = append_partials('storefront.product_description', product: @product)
 
       - if @product.recommendations.any?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,4 +33,4 @@ en:
   workarea:
     storefront:
       products:
-        modified: This product view has been modified
+        modified: The %{product_name} view has been modified

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,7 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  workarea:
+    storefront:
+      products:
+        modified: This product view has been modified


### PR DESCRIPTION
- Use the override generator to override the product/show view
- Update the product show view in our host application to output a static string “This product view has been modified” below the product description.
- Update our implementation to render a dynamic string that reads “The <product name> view has been modified”